### PR TITLE
Update README for running index.html locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,17 @@ This project contains a single HTML page that lists device information that your
 - Time zone
 - Optional geolocation and media devices (may prompt for permission)
 
-Everything runs in the browser—no network requests are required.
+## Viewing locally
+
+For full functionality, serve `index.html` over HTTP instead of opening it
+directly from the filesystem. Many browsers restrict access to geolocation and
+media devices when a page is loaded as a local file. A quick way to serve the
+page is with Python's built‑in HTTP server:
+
+```bash
+python3 -m http.server
+```
+
+Then navigate to `http://localhost:8000/index.html`.
+
+The application runs entirely in the browser — no server-side code is involved.


### PR DESCRIPTION
## Summary
- document how to open `index.html` through a basic HTTP server
- mention permission requirements for geolocation and media devices
- clarify that the app runs entirely on the client side

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848fa1cb65083258d41722cd173d6c0